### PR TITLE
Add Lerna filter option to limit precommit execution to only changed packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lerna run --concurrency 1 --stream precommit"
+      "pre-commit": "lerna run --concurrency 1 --stream precommit --since HEAD"
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,13 @@ package project with [`lerna`][lerna] and [`husky`][husky].
 [husky docs][husky-docs].
 
 The pre-commit hook is configured with the script
-_**`lerna run --concurrency 1 --stream precommit`**_. This executes the
-`precommit` script for each package(if it exists). Furthermore, concurrent
-execution is disabled because it can cause problems during `git add`(see
-[okonet/lint-staged#225][lint-staged-issue-225]).
+_**`lerna run --concurrency 1 --stream precommit --since HEAD`**_. This
+executes the `precommit` script for each package (if it exists). Execution is
+limited to only those packages with file changes by using the `--since HEAD`
+option (see
+[sudo-suhas/lint-staged-multi-pkg#4][lint-staged-multi-pkg-issues-4]).
+Furthermore, concurrent execution is disabled because it can cause problems
+during `git add` (see [okonet/lint-staged#225][lint-staged-issue-225]).
 
 ### `lint-staged` configuration
 
@@ -198,4 +201,5 @@ MIT © [Suhas Karanth][sudo-suhas]
 [sudo-suhas]: https://github.com/sudo-suhas
 [husky-docs]: https://github.com/typicode/husky/blob/v1.3.1/DOCS.md#multi-package-repository-monorepo
 [lint-staged-issue-225]: https://github.com/okonet/lint-staged/issues/225
+[lint-staged-multi-pkg-issues-4]: https://github.com/sudo-suhas/lint-staged-multi-pkg/issues/4
 [npm-run-all]: https://github.com/mysticatea/npm-run-all

--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,10 @@ package project with [`lerna`][lerna] and [`husky`][husky].
 The pre-commit hook is configured with the script
 _**`lerna run --concurrency 1 --stream precommit --since HEAD`**_. This
 executes the `precommit` script for each package (if it exists). Execution is
-limited to only those packages with file changes by using the `--since HEAD`
-option (see
-[sudo-suhas/lint-staged-multi-pkg#4][lint-staged-multi-pkg-issues-4]).
+limited to only those packages with modified files, however the `--since HEAD`
+option does not consider whether the file is staged. To further limit
+`precommit` to only staged files please look at the discussion in
+[sudo-suhas/lint-staged-multi-pkg#4][lint-staged-multi-pkg-issues-4].
 Furthermore, concurrent execution is disabled because it can cause problems
 during `git add` (see [okonet/lint-staged#225][lint-staged-issue-225]).
 


### PR DESCRIPTION
Resolves #4 

Added the `--since HEAD` lerna filter to `husky` `pre-commit` on the root project.

Files changed:
* `package.json`
  * Added [` --since HEAD` Lerna filter option](https://github.com/lerna/lerna/tree/master/core/filter-options#--since-ref) to limit `precommit` execution to only those packages with changed files
* `README.md`
  * Modified **pre-commit hook** with `--since HEAD` addition, and explained why that option is used with link to issue #4

For me `--since HEAD` is an adequate solution to #4, and so have tagged this with `Resolves #4` but I'm open to changing that. Like maybe I should add something to the `README.md` mentioning @jogold other `precommit.js` option https://github.com/sudo-suhas/lint-staged-multi-pkg/issues/4#issuecomment-482492913???

Thanks for providing this sample repository, it's been very helpful! ❤️ 